### PR TITLE
Add iPhone XR/XS Max support

### DIFF
--- a/MobilePlayer/Views/MobilePlayerControlsView.swift
+++ b/MobilePlayer/Views/MobilePlayerControlsView.swift
@@ -56,12 +56,21 @@ final class MobilePlayerControlsView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override func layoutSubviews() {
-
-        let iPhoneX = UIDevice().userInterfaceIdiom == .phone && UIScreen.main.nativeBounds.height == 2436
-        let landscape = UIScreen.main.bounds.height != 812
-
+     override func layoutSubviews() {
         let size = bounds.size
+
+        let iPhoneX = UIDevice.current.userInterfaceIdiom == .phone && (UIScreen.main.nativeBounds.height == 2688 || UIScreen.main.nativeBounds.height == 2436 || UIScreen.main.nativeBounds.height == 1792)
+        let landscape = UIDevice.current.orientation.isLandscape
+        var topSafeAreaHeight: CGFloat = 0.0
+        var bottomSafeAreaHeight: CGFloat = 0.0
+
+        if #available(iOS 11.0, *) {
+            let window = UIApplication.shared.windows[0]
+            let safeFrame = window.safeAreaLayoutGuide.layoutFrame
+            topSafeAreaHeight = safeFrame.minY
+            bottomSafeAreaHeight = window.frame.maxY - safeFrame.maxY
+        }
+
         previewImageView.frame = bounds
         activityIndicatorView.sizeToFit()
         activityIndicatorView.frame.origin = CGPoint(
@@ -70,14 +79,14 @@ final class MobilePlayerControlsView: UIView {
         topBar.sizeToFit()
         topBar.frame = CGRect(
             x: (iPhoneX && landscape) ? 44 : 0,
-            y: controlsHidden ? -topBar.frame.size.height : ((iPhoneX && !landscape) ? 44 : 0),
+            y: controlsHidden ? -topBar.frame.size.height : topSafeAreaHeight,
             width: size.width - ((iPhoneX && landscape) ? 88 : 0),
             height: topBar.frame.size.height)
         topBar.alpha = controlsHidden ? 0 : 1
         bottomBar.sizeToFit()
         bottomBar.frame = CGRect(
             x: (iPhoneX && landscape) ? 44 : 0,
-            y: size.height - (controlsHidden ? 0 : bottomBar.frame.size.height + ((iPhoneX && !landscape) ? 34 : 0)),
+            y: size.height - (controlsHidden ? 0 : bottomBar.frame.size.height + bottomSafeAreaHeight),
             width: size.width - ((iPhoneX && landscape) ? 88 : 0),
             height: bottomBar.frame.size.height)
         bottomBar.alpha = controlsHidden ? 0 : 1


### PR DESCRIPTION

The original Pod MobilePlayer does not have notch support yet. Support for iPhone X/XS has been implemented in the fork.

* Added support for iPhone XR and XS Max for portrait and landscape orientation.

Screenshot - 
![Screenshot 2019-04-03 at 3 22 33 PM](https://user-images.githubusercontent.com/30552772/55479615-1ca34780-563c-11e9-837f-bed7e573b8a2.png)

![Screenshot 2019-04-03 at 6 03 41 PM](https://user-images.githubusercontent.com/30552772/55479660-2fb61780-563c-11e9-9d4e-4b8a0b2e947c.png)
